### PR TITLE
Add optional alphabetical sorting feature for project scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,11 @@
 					"default": false,
 					"description": "Show inherited resources in the Ignition Project Scripts view."
 				},
+				"ignitionFlint.sortProjectScripts": {
+					"type": "boolean",
+					"default": false,
+					"description": "Sort projects and scripts alphabetically in the Ignition Project Scripts view."
+				},
 				"ignitionFlint.sslVerify": {
 					"type": "boolean",
 					"default": true,
@@ -203,6 +208,11 @@
 			{
 				"command": "ignition-flint.toggle-inherited-resource-visibility",
 				"title": "Toggle Inherited Resource Visibility",
+				"category": "Ignition Flint"
+			},
+			{
+				"command": "ignition-flint.toggle-sort-project-scripts",
+				"title": "Toggle Alphabetical Sorting",
 				"category": "Ignition Flint"
 			},
 			{

--- a/src/commandRegistration.ts
+++ b/src/commandRegistration.ts
@@ -210,6 +210,7 @@ export function registerCommands(context: vscode.ExtensionContext, dependencyCon
 
 	subscriptionManager.add(vscode.commands.registerCommand('ignition-flint.show-options', async () => {
 		const showInheritedResources = vscode.workspace.getConfiguration('ignitionFlint').get('showInheritedResources', false);
+		const sortProjectScripts = vscode.workspace.getConfiguration('ignitionFlint').get('sortProjectScripts', false);
 		interface CustomQuickPickItem extends vscode.QuickPickItem {
 			command: string;
 		}
@@ -224,6 +225,11 @@ export function registerCommands(context: vscode.ExtensionContext, dependencyCon
 				label: showInheritedResources ? 'Hide Inherited Code' : 'Show Inherited Code',
 				description: 'Toggle the visibility of inherited resources',
 				command: 'ignition-flint.toggle-inherited-resource-visibility'
+			},
+			{
+				label: sortProjectScripts ? 'Disable Alphabetical Sorting' : 'Enable Alphabetical Sorting',
+				description: 'Toggle alphabetical sorting of projects and scripts',
+				command: 'ignition-flint.toggle-sort-project-scripts'
 			}
 		];
 
@@ -239,6 +245,12 @@ export function registerCommands(context: vscode.ExtensionContext, dependencyCon
 	subscriptionManager.add(vscode.commands.registerCommand('ignition-flint.toggle-inherited-resource-visibility', async () => {
 		const showInheritedResources = vscode.workspace.getConfiguration('ignitionFlint').get('showInheritedResources', false);
 		await vscode.workspace.getConfiguration('ignitionFlint').update('showInheritedResources', !showInheritedResources, vscode.ConfigurationTarget.Workspace);
+		ignitionFileSystemProvider.refreshTreeView();
+	}));
+
+	subscriptionManager.add(vscode.commands.registerCommand('ignition-flint.toggle-sort-project-scripts', async () => {
+		const sortProjectScripts = vscode.workspace.getConfiguration('ignitionFlint').get('sortProjectScripts', false);
+		await vscode.workspace.getConfiguration('ignitionFlint').update('sortProjectScripts', !sortProjectScripts, vscode.ConfigurationTarget.Workspace);
 		ignitionFileSystemProvider.refreshTreeView();
 	}));
 

--- a/src/providers/ignitionFileSystem.ts
+++ b/src/providers/ignitionFileSystem.ts
@@ -334,6 +334,12 @@ export class IgnitionFileSystemProvider implements vscode.TreeDataProvider<Ignit
 			projectMap.set(project.projectId, project);
 		}
 
+		// Sort projects alphabetically by title first if setting is enabled
+		const sortAlphabetically = vscode.workspace.getConfiguration('ignitionFlint').get('sortProjectScripts', false);
+		const projectsToProcess = sortAlphabetically
+			? [...projects].sort((a, b) => a.title.localeCompare(b.title))
+			: projects;
+
 		// Recursively sort the projects based on their parent-child relationship, making sure parents are first
 		const sortProjectsRecursive = (project: IgnitionProjectResource) => {
 			if (project.parentProject) {
@@ -345,7 +351,7 @@ export class IgnitionFileSystemProvider implements vscode.TreeDataProvider<Ignit
 			}
 		};
 
-		for (const project of projects) {
+		for (const project of projectsToProcess) {
 			sortProjectsRecursive(project);
 
 			// Add any projects that were not included in the recursive sorting
@@ -402,6 +408,13 @@ export class IgnitionFileSystemProvider implements vscode.TreeDataProvider<Ignit
 					folderResources.push(folderResource);
 				}
 			}
+		}
+
+		// Sort folders and scripts alphabetically by name if setting is enabled
+		const sortAlphabetically = vscode.workspace.getConfiguration('ignitionFlint').get('sortProjectScripts', false);
+		if (sortAlphabetically) {
+			folderResources.sort((a, b) => a.label.localeCompare(b.label));
+			scriptResources.sort((a, b) => a.label.localeCompare(b.label));
 		}
 
 		resources = [...folderResources, ...scriptResources];

--- a/src/resources/scriptResource.ts
+++ b/src/resources/scriptResource.ts
@@ -103,6 +103,19 @@ export class ScriptResource extends IgnitionFileResource implements TreeViewItem
 				}
 			});
 
+			// Sort script elements alphabetically if setting is enabled
+			const sortAlphabetically = vscode.workspace.getConfiguration('ignitionFlint').get('sortProjectScripts', false);
+			if (sortAlphabetically) {
+				resources.sort((a, b) => a.label.localeCompare(b.label));
+
+				// Also sort methods within classes
+				resources.forEach(element => {
+					if (element instanceof ClassElement && element.children) {
+						element.children.sort((a, b) => a.label.localeCompare(b.label));
+					}
+				});
+			}
+
 			this.scriptElements = resources;
 			this.children = resources;
 		} catch (error) {


### PR DESCRIPTION
This commit adds a new user-configurable setting to enable alphabetical sorting in the Ignition Project Scripts view. The feature is controlled by the `ignitionFlint.sortProjectScripts` setting and defaults to `false` to preserve existing behavior.

When enabled, the feature sorts:
- Projects alphabetically by title (while preserving parent-child inheritance hierarchy)
- Scripts and folders within each project alphabetically by name
- Functions, classes, and constants within scripts alphabetically
- Methods within classes alphabetically

The setting can be toggled via:
1. VSCode Settings UI (search for "sort project scripts")
2. Quick options menu (three dots icon next to "Ignition Project Scripts")

Changes include:
- Added `sortProjectScripts` configuration property to package.json
- Added toggle command for alphabetical sorting
- Updated show-options menu to include sorting toggle
- Implemented conditional sorting in scriptResource.ts for script elements
- Implemented conditional sorting in ignitionFileSystem.ts for folders, scripts, and projects

🤖 Generated with [Claude Code](https://claude.com/claude-code)