### PR TITLE
refactor: allow for default icons and scm decorators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/*
+out/*
+.vscode-test

--- a/src/commands/resources/CopyPathCommand.ts
+++ b/src/commands/resources/CopyPathCommand.ts
@@ -11,6 +11,7 @@ import { Command } from '@/commands/base/Command';
 import { COMMANDS } from '@/core/constants/commands';
 import { FlintError, InvalidArgumentError } from '@/core/errors';
 import { CommandContext, CommandValidationResult } from '@/core/types/commands';
+import { TreeNode } from '@/core/types/tree';
 
 /**
  * Command to copy a resource path to the clipboard
@@ -21,8 +22,10 @@ export class CopyPathCommand extends Command {
         super(COMMANDS.COPY_RESOURCE_PATH, context);
     }
 
-    protected validateArguments(resourcePath?: string, _pathType?: string): CommandValidationResult {
+    protected validateArguments(resourcePathOrNode?: string | TreeNode, _pathType?: string): CommandValidationResult {
         const errors: string[] = [];
+
+        const resourcePath = this.extractResourcePath(resourcePathOrNode);
 
         if (resourcePath === undefined || resourcePath === '') {
             errors.push('Resource path is required');
@@ -35,9 +38,11 @@ export class CopyPathCommand extends Command {
         };
     }
 
-    protected async executeImpl(resourcePath?: string, pathType: string = 'resource'): Promise<void> {
+    protected async executeImpl(resourcePathOrNode?: string | TreeNode, pathType: string = 'resource'): Promise<void> {
+        const resourcePath = this.extractResourcePath(resourcePathOrNode);
+
         if (resourcePath === undefined || resourcePath === '') {
-            throw new InvalidArgumentError('arguments', 'resourcePath', [resourcePath]);
+            throw new InvalidArgumentError('arguments', 'resourcePath or TreeNode', [resourcePathOrNode]);
         }
 
         try {
@@ -71,6 +76,29 @@ export class CopyPathCommand extends Command {
                 error instanceof Error ? error : undefined
             );
         }
+    }
+
+    /**
+     * Extracts a resource path from direct string input or a tree node.
+     */
+    private extractResourcePath(resourcePathOrNode?: string | TreeNode): string | undefined {
+        if (typeof resourcePathOrNode === 'string') {
+            return resourcePathOrNode;
+        }
+
+        if (resourcePathOrNode && typeof resourcePathOrNode === 'object') {
+            const nodeWithOriginalPath = resourcePathOrNode as TreeNode & { originalResourcePath?: unknown };
+
+            if (typeof nodeWithOriginalPath.originalResourcePath === 'string') {
+                return nodeWithOriginalPath.originalResourcePath;
+            }
+
+            if (typeof resourcePathOrNode.resourcePath === 'string') {
+                return resourcePathOrNode.resourcePath;
+            }
+        }
+
+        return undefined;
     }
 
     /**

--- a/src/commands/resources/DeleteResourceCommand.ts
+++ b/src/commands/resources/DeleteResourceCommand.ts
@@ -89,7 +89,7 @@ export class DeleteResourceCommand extends Command {
             const node = nodeOrProjectId;
             actualProjectId = node.projectId!;
             actualTypeId = node.resourceType ?? (node as any).typeId;
-            actualResourcePath = node.resourcePath!;
+            actualResourcePath = (node as any).originalResourcePath ?? node.resourcePath!;
             actualCategoryId = node.categoryId ?? (node as any).categoryId;
 
             console.log(

--- a/src/providers/resources/PythonScriptProvider.ts
+++ b/src/providers/resources/PythonScriptProvider.ts
@@ -122,10 +122,7 @@ export class PythonScriptProvider extends BaseResourceTypeProvider {
                     resourceTypeId: 'script-python',
                     description: 'Empty Python script with basic structure',
                     files: {
-                        'code.py':
-                            '# New Python Script\n\n' +
-                            'def main():\n    """Main function - add your code here"""\n    pass\n\n' +
-                            'if __name__ == "__main__":\n    main()\n',
+                        'code.py': '',
                         'resource.json': JSON.stringify(
                             {
                                 scope: 'A',
@@ -139,38 +136,14 @@ export class PythonScriptProvider extends BaseResourceTypeProvider {
                             2
                         )
                     }
-                },
-                {
-                    id: 'gateway-script',
-                    name: 'Gateway Event Script',
-                    resourceTypeId: 'script-python',
-                    description: 'Template for gateway event scripts',
-                    files: {
-                        'code.py':
-                            '# Gateway Event Script\n\ndef runAction(self):\n    """Runs when the gateway event triggers"""\n    logger = system.util.getLogger("GatewayScript")\n    logger.info("Gateway event script executed")\n    \n    # Add your event handling code here\n    pass\n',
-                        'resource.json': JSON.stringify(
-                            {
-                                scope: 'G',
-                                version: 1,
-                                restricted: false,
-                                overridable: false,
-                                files: ['code.py'],
-                                attributes: {}
-                            },
-                            null,
-                            2
-                        )
-                    }
                 }
             ],
             defaultTemplateId: 'basic-python',
             generateDefaultContent: (templateId?: string): string => {
                 switch (templateId) {
-                    case 'gateway-script':
-                        return '# Gateway Event Script\n\ndef runAction(self):\n    """Runs when the gateway event triggers"""\n    # Add your code here\n    pass\n';
                     case 'basic-python':
                     default:
-                        return '# New Python Script\n\ndef main():\n    """Main function - add your code here"""\n    pass\n\nif __name__ == "__main__":\n    main()\n';
+                        return '';
                 }
             }
         };

--- a/src/views/projectBrowser/ProjectTreeDataProvider.ts
+++ b/src/views/projectBrowser/ProjectTreeDataProvider.ts
@@ -4,6 +4,7 @@
  * Provides tree view functionality with service-based architecture
  */
 
+import * as fs from 'fs';
 import * as path from 'path';
 
 import * as vscode from 'vscode';
@@ -149,7 +150,17 @@ export class ProjectTreeDataProvider implements vscode.TreeDataProvider<TreeNode
             item.contextValue = element.contextValue;
 
             // Apply decorations using decoration provider
-            const treeItem = {
+            const treeItem: {
+                label: string;
+                id?: string;
+                iconPath?: vscode.ThemeIcon;
+                description?: string;
+                tooltip?: string;
+                collapsibleState?: vscode.TreeItemCollapsibleState;
+                contextValue?: string;
+                command?: vscode.Command;
+                resourceUri?: vscode.Uri;
+            } = {
                 label: item.label as string,
                 id: item.id,
                 iconPath: undefined,
@@ -162,9 +173,21 @@ export class ProjectTreeDataProvider implements vscode.TreeDataProvider<TreeNode
 
             this.decorationProvider.applyDecorations(treeItem, element);
 
+            const resourceUri = this.resolveResourceUri(element);
+            if (resourceUri) {
+                treeItem.resourceUri = resourceUri;
+            }
+
+            if (resourceUri && this.shouldUseDefaultResourceIcon(treeItem.iconPath)) {
+                treeItem.iconPath = this.getDefaultResourceIcon(element, resourceUri);
+            }
+
             // Copy back to VS Code tree item
             if (treeItem.iconPath) {
                 (item as any).iconPath = treeItem.iconPath;
+            }
+            if (treeItem.resourceUri) {
+                item.resourceUri = treeItem.resourceUri;
             }
             item.contextValue = treeItem.contextValue;
             item.tooltip = treeItem.tooltip;
@@ -784,6 +807,171 @@ export class ProjectTreeDataProvider implements vscode.TreeDataProvider<TreeNode
 
         const projectPath = project?.projectPath;
         return typeof projectPath === 'string' ? projectPath : null;
+    }
+
+    /**
+     * Resolves a resource URI for tree items so VS Code can apply default icon themes and SCM decorations.
+     */
+    private resolveResourceUri(element: TreeNode): vscode.Uri | undefined {
+        if (!this.isResourceNodeWithPath(element)) {
+            return undefined;
+        }
+
+        const typeId = element.typeId || element.resourceType;
+        if (!typeId) {
+            return undefined;
+        }
+
+        const projectPath = this.resolveProjectPathForNode(element);
+        if (!projectPath) {
+            return undefined;
+        }
+
+        const { resourceDirectory, primaryFile } = this.getResourceProviderPaths(typeId);
+        const relativePath = this.stripResourceDirectoryPrefix(element.resourcePath, resourceDirectory);
+        const resourceDirectoryPath = path.join(projectPath, resourceDirectory, relativePath);
+
+        if (element.type === TreeNodeType.RESOURCE_FOLDER) {
+            return this.resolveFolderResourceUri(resourceDirectoryPath);
+        }
+
+        if (typeof primaryFile === 'string' && primaryFile.length > 0) {
+            const primaryFilePath = path.join(resourceDirectoryPath, primaryFile);
+            if (this.pathExists(primaryFilePath)) {
+                return vscode.Uri.file(primaryFilePath);
+            }
+        }
+
+        return vscode.Uri.file(resourceDirectoryPath);
+    }
+
+    /**
+     * Checks whether a node maps to a filesystem-backed resource location.
+     */
+    private isResourceNodeWithPath(
+        element: TreeNode
+    ): element is TreeNode & { resourcePath: string; projectId: string } {
+        return Boolean(
+            element.resourcePath &&
+                element.projectId &&
+                (element.type === TreeNodeType.RESOURCE_ITEM ||
+                    element.type === TreeNodeType.SINGLETON_RESOURCE ||
+                    element.type === TreeNodeType.RESOURCE_FOLDER)
+        );
+    }
+
+    /**
+     * Resolves project path for local or inherited resource nodes.
+     */
+    private resolveProjectPathForNode(element: TreeNode & { projectId: string }): string | null {
+        const elementWithSource = element as TreeNode & { sourceProject?: string };
+        const sourceProject =
+            typeof elementWithSource.sourceProject === 'string' ? elementWithSource.sourceProject : element.projectId;
+        return this.findProjectPath(sourceProject) || this.findProjectPath(element.projectId);
+    }
+
+    /**
+     * Gets provider-specific resource directory and primary file.
+     */
+    private getResourceProviderPaths(typeId: string): { resourceDirectory: string; primaryFile?: string } {
+        const resourceTypeRegistry = this.serviceContainer.get<any>('ResourceTypeProviderRegistry');
+        const provider = resourceTypeRegistry?.getProvider?.(typeId);
+        const searchConfig = provider?.getSearchConfig?.();
+        const editorConfig = provider?.getEditorConfig?.();
+
+        const resourceDirectory = Array.isArray(searchConfig?.directoryPaths) ? searchConfig.directoryPaths[0] : '';
+        const primaryFile =
+            typeof editorConfig?.primaryFile === 'string' && editorConfig.primaryFile.length > 0
+                ? editorConfig.primaryFile
+                : undefined;
+
+        return { resourceDirectory, primaryFile };
+    }
+
+    /**
+     * Resolves folder URI, preferring code.py when present.
+     */
+    private resolveFolderResourceUri(resourceDirectoryPath: string): vscode.Uri {
+        const codePyPath = path.join(resourceDirectoryPath, 'code.py');
+        if (this.pathExists(codePyPath)) {
+            return vscode.Uri.file(codePyPath);
+        }
+
+        return vscode.Uri.file(resourceDirectoryPath);
+    }
+
+    /**
+     * Removes provider directory prefix from a resource path when needed.
+     */
+    private stripResourceDirectoryPrefix(resourcePath: string, resourceDirectory: string): string {
+        if (!resourceDirectory) {
+            return resourcePath;
+        }
+
+        const normalizedResourcePath = resourcePath.replace(/\\/g, '/');
+        const normalizedResourceDirectory = resourceDirectory.replace(/\\/g, '/').replace(/^\/+|\/+$/g, '');
+
+        if (normalizedResourcePath === normalizedResourceDirectory) {
+            return '';
+        }
+
+        if (normalizedResourcePath.startsWith(`${normalizedResourceDirectory}/`)) {
+            return normalizedResourcePath.substring(normalizedResourceDirectory.length + 1);
+        }
+
+        return resourcePath;
+    }
+
+    /**
+     * Determines whether icon should use VS Code's default file/folder theme icon.
+     */
+    private shouldUseDefaultResourceIcon(iconPath: unknown): boolean {
+        if (!(iconPath instanceof vscode.ThemeIcon)) {
+            return true;
+        }
+
+        return iconPath.id !== 'warning' && iconPath.id !== 'error';
+    }
+
+    /**
+     * Chooses default file/folder icon using resource URI context.
+     */
+    private getDefaultResourceIcon(element: TreeNode, resourceUri: vscode.Uri): vscode.ThemeIcon {
+        if (resourceUri.fsPath.endsWith(`${path.sep}code.py`)) {
+            return vscode.ThemeIcon.File;
+        }
+
+        if (this.isDirectoryPath(resourceUri.fsPath)) {
+            return vscode.ThemeIcon.Folder;
+        }
+
+        if (element.type === TreeNodeType.RESOURCE_FOLDER) {
+            return vscode.ThemeIcon.Folder;
+        }
+
+        return vscode.ThemeIcon.File;
+    }
+
+    /**
+     * Safe path existence check.
+     */
+    private pathExists(targetPath: string): boolean {
+        try {
+            return fs.existsSync(targetPath);
+        } catch {
+            return false;
+        }
+    }
+
+    /**
+     * Safe directory check for URI path icon selection.
+     */
+    private isDirectoryPath(targetPath: string): boolean {
+        try {
+            return fs.statSync(targetPath).isDirectory();
+        } catch {
+            return false;
+        }
     }
 
     /**


### PR DESCRIPTION
Current functionality uses custom folders and icons. This PR renders the default icons to allow users to use their own icon library such as [Material Icons](https://open-vsx.org/extension/PKief/material-icon-theme). This also allows the user to see the source control status of each file. This was a feature that was originally in the 8.1 version. 

Other QOL features:

- Removed boilerplate code for python resources
- Added .gitignore